### PR TITLE
Support Multiple Captcha Instances

### DIFF
--- a/src/BotDetectCaptcha.php
+++ b/src/BotDetectCaptcha.php
@@ -15,7 +15,7 @@ class BotDetectCaptcha
     /**
      * @var object
      */
-    private static $instance;
+    private static $instances = [];
 
     /**
      * BotDetect Laravel CAPTCHA package information.
@@ -32,7 +32,7 @@ class BotDetectCaptcha
      */
     public function __construct($configName, $captchaInstanceId = null)
     {
-        self::$instance = $this;
+        self::$instances[$configName] = $this;
 
         // load BotDetect Library
         LibraryLoader::load();
@@ -79,9 +79,9 @@ class BotDetectCaptcha
      *
      * @return object
      */
-    public static function getInstance()
+    public static function getInstance($configName)
     {
-        return self::$instance;
+        return array_key_exists($configName, self::$instances) ? self::$instances[$configName] : null;
     }
 
     public function __call($method, $args = array())

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -69,7 +69,7 @@ if (! function_exists('captcha_instance')) {
      */
     function captcha_instance($captchaId)
     {
-        $captcha = BotDetectCaptcha::getInstance();
+        $captcha = BotDetectCaptcha::getInstance($captchaId);
         return (null !== $captcha) ? $captcha : new BotDetectCaptcha($captchaId);
     }
 }


### PR DESCRIPTION
At the moment it is not possible to have two captcha images on one page with different config names.
This happens because it saves the first instance and reuses this for all future actions.

With this change it saves the instance together with the config name. This solves the problem of reusing the same instance for different config names.